### PR TITLE
Update search input element id in script.js

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,7 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
         e.preventDefault();
 
         const submitButton = frmSearch.querySelector("button[type=submit]");
-        const query = document.getElementById('q_search').value;
+        const query = document.getElementById('q').value;
         const maxResults = document.getElementById('max_results').value;
 
         submitButton.classList.add("disabled");


### PR DESCRIPTION
Incorrect search element id was causing the following error:

```
script.js:34  Uncaught TypeError: Cannot read properties of null (reading 'value')
    at HTMLFormElement.<anonymous> (VM282 script.js:34:58)
```
