### PR TITLE
Update nav.php to use relative path hyperlinks

### DIFF
--- a/includes/nav.php
+++ b/includes/nav.php
@@ -8,7 +8,7 @@ if ($currentPath === '') {
 }
 
 // Use the basename function to check if we're in the "logs" folder.
-$brandHref = ($currentPath === '/') ? '.' : '..';
+$brandHref = (basename($currentPath) === 'logs') ? '..' : '.';
 $logsHref  = (basename($currentPath) === 'logs') ? '.' : 'logs';
 ?>
 

--- a/includes/nav.php
+++ b/includes/nav.php
@@ -1,5 +1,19 @@
+<?php
+// Get the path from the request URI and remove any trailing slash.
+$currentPath = rtrim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
+
+// If the path is empty, assume it's the root.
+if ($currentPath === '') {
+    $currentPath = '/';
+}
+
+// Use the basename function to check if we're in the "logs" folder.
+$brandHref = ($currentPath === '/') ? '.' : '..';
+$logsHref  = (basename($currentPath) === 'logs') ? '.' : 'logs';
+?>
+
 <nav class="navbar navbar-expand-lg">
-    <a class="navbar-brand" href="<?= $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] ?>">Youtube converter</a>
+    <a class="navbar-brand" href="<?= $brandHref ?>">Youtube converter</a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNavDropdown"
         aria-controls="mainNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
@@ -8,7 +22,7 @@
     <div class="collapse navbar-collapse" id="mainNavDropdown">
         <ul class="navbar-nav">
             <li class="nav-item">
-                <a class="nav-link" href="/logs">Logs</a>
+                <a class="nav-link" href="<?= $logsHref ?>">Logs</a>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
This pull request removes the dependency of placing the project at the root level of a website.

1. Nav.php uses relative path for the hyperlinks
2. Hyperlink paths are adjusted dynamically (depending upon where the module is called from, /index.php or logs/index.php)

Example:

www.website.com/something/index.php ✅  (Relative hyperlinks still work in this case)